### PR TITLE
.gitignore 에 jpa buddy 플로그인의 설정 파일을 무시하도록 룰 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ cmake-build-*/
 # IntelliJ
 out/
 
+### JPA buddy
+.jpb/
+
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 


### PR DESCRIPTION
intellij plugin 중 jpa 작업을 편히 해주는 jpa buddy라는 플러그인으로 인해 자동 생성되는 설정 파일이 프로젝트에 포함되지 않도록 파일 무시 규칙을 추가함