### PR TITLE
error-repair

### DIFF
--- a/src/test/java/com/mumy/basicboard/controller/AuthControllerTest.java
+++ b/src/test/java/com/mumy/basicboard/controller/AuthControllerTest.java
@@ -1,12 +1,11 @@
 package com.mumy.basicboard.controller;
 
-import com.mumy.basicboard.config.SecurityConfig;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -18,6 +17,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class AuthControllerTest {
 
     private final MockMvc mvc;
+    @MockBean
+    ArticleController articleController;
 
     public AuthControllerTest(@Autowired MockMvc mvc) {this.mvc = mvc;}
 


### PR DESCRIPTION
스프링 시큐리티에서 의존성에 의한 테스트 탈락의 오류를 수정하기 위해 MockBean 추가