### PR TITLE
헤로쿠에 배포하기 - DB변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,7 +38,7 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always
 


### PR DESCRIPTION
조사해본 결과, cleardb 의 기본 mysql 버전이 `5.6`으로 너무 낮기 때문에 문제가 발생함 
(5.6 버전에서는 `article_comment.content`인덱스 사이즈가 너무 커서 생긴 문제)
 대안으로 jawsdb를 찾아냄 기본 mysql 버전`8.0`으로 확인
이를 이용해 환경변수 다시 작업함

This fixes #48 