### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(),hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/com/mumy/basicboard/domain/Article.java
+++ b/src/main/java/com/mumy/basicboard/domain/Article.java
@@ -58,13 +58,13 @@ public class Article extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }
 

--- a/src/main/java/com/mumy/basicboard/domain/ArticleComment.java
+++ b/src/main/java/com/mumy/basicboard/domain/ArticleComment.java
@@ -48,12 +48,12 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }
 

--- a/src/main/java/com/mumy/basicboard/domain/UserAccount.java
+++ b/src/main/java/com/mumy/basicboard/domain/UserAccount.java
@@ -51,13 +51,13 @@ public class UserAccount extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
+        if (!(o instanceof UserAccount that)) return false;
 
-        return userId != null && userId.equals(userAccount.userId);
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
이 pr은 프록시 객체를 다룰 때 필드 값이 null일 수 있는 문제가 있습니다.
이를 해결하기 위해 프로퍼티 직접 접근이 아닌 getter()를 사용한 접근을 하여 문제를 해결하였습니다.